### PR TITLE
Improve survey pages user interface

### DIFF
--- a/usaon_benefit_tool/routes/survey.py
+++ b/usaon_benefit_tool/routes/survey.py
@@ -4,6 +4,7 @@ from flask_login import login_required
 from usaon_benefit_tool import db
 from usaon_benefit_tool.forms import FORMS_BY_MODEL
 from usaon_benefit_tool.models.tables import Survey
+from usaon_benefit_tool.util.full_sankey import sankey
 
 survey_bp = Blueprint('survey', __name__, url_prefix='/survey')
 
@@ -35,4 +36,8 @@ def view_survey(survey_id: str):
     # Fetch survey by id
     survey = db.get_or_404(Survey, survey_id)
 
-    return render_template('survey.html', survey=survey)
+    return render_template(
+        'survey.html',
+        survey=survey,
+        sankey_series=sankey(survey.response) if survey.response else [],
+    )

--- a/usaon_benefit_tool/templates/macros/javascript_highcharts.j2
+++ b/usaon_benefit_tool/templates/macros/javascript_highcharts.j2
@@ -16,8 +16,25 @@
       },
       series: [{
         keys: ['from', 'to', 'weight'],
-        data: {{sankey_series | safe}},
+        data: {{ sankey_series | safe }},
       }]
     });
   </script>
+{% endmacro %}
+
+
+{% macro display_sankey(sankey_series) -%}
+  {% include 'includes/highcharts.html' %}
+  <h4>Diagram</h4>
+
+  {% if sankey_series == [] %}
+    <div class="alert alert-info">
+      Please input at least one relationship to display diagram
+    </div>
+  {% else %}
+    <figure class="highcharts-figure">
+      <div id="highcharts-container" />
+    </figure>
+    {{ add_javascript__highcharts(sankey_series) }}
+  {% endif %}
 {% endmacro %}

--- a/usaon_benefit_tool/templates/response/applications.html
+++ b/usaon_benefit_tool/templates/response/applications.html
@@ -1,12 +1,10 @@
 {% extends 'response/base.html' %}
 {% from 'bootstrap5/form.html' import render_form %}
 {% from 'bootstrap5/utils.html' import render_icon %}
-{% from 'macros/javascript_highcharts.j2' import add_javascript__highcharts %}
+{% from 'macros/javascript_highcharts.j2' import display_sankey %}
 {% from 'macros/javascript_remove.j2' import add_javascript__remove %}
 
 {% block content %}
-  {% include 'includes/highcharts.html' %}
-
   {{super()}}
 
   <h3>Applications</h3>
@@ -85,14 +83,7 @@
       </table>
     </div>
 
-    {% if sankey_series == [] %}
-      <div>Please input at least one application-to-dataproduct relationship to display diagram</div>
-    {% else %}
-      <figure class="highcharts-figure">
-        <div id="highcharts-container" />
-      </figure>
-      {{ add_javascript__highcharts(sankey_series) }}
-    {% endif %}
+    {{ display_sankey(sankey_series) }}
   </div>
 
   {% if not current_user.role_id not in ['admin', 'respondent'] %}

--- a/usaon_benefit_tool/templates/response/data_products.html
+++ b/usaon_benefit_tool/templates/response/data_products.html
@@ -1,12 +1,10 @@
 {% extends 'response/base.html' %}
 {% from 'bootstrap5/form.html' import render_form %}
 {% from 'bootstrap5/utils.html' import render_icon %}
-{% from 'macros/javascript_highcharts.j2' import add_javascript__highcharts %}
+{% from 'macros/javascript_highcharts.j2' import display_sankey %}
 {% from 'macros/javascript_remove.j2' import add_javascript__remove %}
 
 {% block content %}
-  {% include 'includes/highcharts.html' %}
-
   {{super()}}
 
   <h3>Data products</h3>
@@ -86,14 +84,7 @@
       </table>
     </div>
 
-    {% if sankey_series == [] %}
-      <div>Please input at least one dataproduct-to-observing systems relationship to display diagram</div>
-    {% else %}
-      <figure class="highcharts-figure">
-        <div id="highcharts-container" />
-      </figure>
-      {{ add_javascript__highcharts(sankey_series) }}
-    {% endif %}
+    {{ display_sankey(sankey_series) }}
   </div>
 
 

--- a/usaon_benefit_tool/templates/response/sbas.html
+++ b/usaon_benefit_tool/templates/response/sbas.html
@@ -2,12 +2,10 @@
 {% from 'bootstrap5/form.html' import render_form %}
 {% from 'bootstrap5/utils.html' import render_icon %}
 {% from 'macros/javascript_remove.j2' import add_javascript__remove %}
-{% from 'macros/javascript_highcharts.j2' import add_javascript__highcharts %}
+{% from 'macros/javascript_highcharts.j2' import display_sankey %}
 
 
 {% block content %}
-  {% include 'includes/highcharts.html' %}
-
   {{super()}}
 
   <div class="two-columns">
@@ -85,14 +83,8 @@
       {% endif %}
     </div>
 
-    {% if sankey_series == [] %}
-      <div>Please input at least one relationship to display diagram</div>
-    {% else %}
-      <figure class="highcharts-figure">
-        <div id="highcharts-container" />
-      </figure>
-      {{ add_javascript__highcharts(sankey_series) }}
-    {% endif %}
+    {{ display_sankey(sankey_series) }}
   </div>
+
   {{ add_javascript__remove() }}
 {% endblock %}

--- a/usaon_benefit_tool/templates/response/view.html
+++ b/usaon_benefit_tool/templates/response/view.html
@@ -1,22 +1,14 @@
 {% extends 'response/base.html' %}
-{% from 'macros/javascript_highcharts.j2' import add_javascript__highcharts %}
+{% from 'macros/javascript_highcharts.j2' import display_sankey %}
 
 
 {% block content %}
-  {% include 'includes/highcharts.html' %}
 
   {{super()}}
 
   <p>Created: {{response.created_timestamp}}</p>
   <p>Last updated: {{response.updated_timestamp}}</p>
 
-  {% if sankey_series == [] %}
-    <div>Please input at least one relationship to display diagram</div>
-  {% else %}
-    <figure class="highcharts-figure">
-      <div id="highcharts-container" />
-    </figure>
-    {{ add_javascript__highcharts(sankey_series) }}
-  {% endif %}
+  {{ display_sankey(sankey_series) }}
 
 {% endblock %}

--- a/usaon_benefit_tool/templates/survey.html
+++ b/usaon_benefit_tool/templates/survey.html
@@ -1,28 +1,50 @@
 {% extends 'base.html' %}
-
+{% from 'macros/javascript_highcharts.j2' import add_javascript__highcharts %}
 
 {% block content %}
 
-  <h2>{% block title %}Survey Title: {{survey.title}}{% endblock %}</h2>
-  <h4>Survey ID : {{survey.id}}</h4>
-
-  <i>Created: {{survey.created_timestamp}}</i>
-
-  <h3>Notes</h3>
+  <h2>{% block title %}Title: {{survey.title}}{% endblock %}</h2>
+  
+  <br>
+  <h3>Description</h3>
   <p>{{survey.description}}</p>
-
-  <h3>Response</h3>
 
   {% if survey.response_id %}
     <a href="{{url_for('response.view_response', survey_id=survey.id, _external=True)}}">
-      View response
+      View or edit response
     </a>
-    <p> Response by: {{ survey.response.created_by.email}} </p>
+    <p> Response created by: {{ survey.response.created_by.email}} </p>
   {% else %}
     <p>No response available.</p>
     <a href="{{url_for('response.view_response', survey_id=survey.id, _external=True)}}">
       Create response
     </a>
+
+  <br>
+  <h4>Diagram</h4>
+
+
+{% block content %}
+  {% include 'includes/highcharts.html' %}
+
+  {{super()}}
+
+  <p>Created: {{response.created_timestamp}}</p>
+  <p>Last updated: {{response.updated_timestamp}}</p>
+
+  {% if sankey_series == [] %}
+    <div>Please input at least one relationship to display diagram</div>
+  {% else %}
+    <figure class="highcharts-figure">
+      <div id="highcharts-container" />
+    </figure>
+    {{ add_javascript__highcharts(sankey_series) }}
+  {% endif %}
+
+  <br>
+  <i>ID : {{survey.id}}</i>
+
+  <i>Created: {{survey.created_timestamp}}</i>
 
     <p><i>
       IMPORTANT: Advise respondents that this application does not support concurrent or collaborative editing.

--- a/usaon_benefit_tool/templates/survey.html
+++ b/usaon_benefit_tool/templates/survey.html
@@ -1,55 +1,53 @@
 {% extends 'base.html' %}
+{% from 'bootstrap5/utils.html' import render_icon %}
 {% from 'macros/javascript_highcharts.j2' import add_javascript__highcharts %}
 
 {% block content %}
 
-  <h2>{% block title %}Title: {{survey.title}}{% endblock %}</h2>
-  
-  <br>
+  <h2>{% block title %}Survey #{{survey.id}}: {{survey.title}}{% endblock %}</h2>
+
+  <p><i>Created: {{survey.created_timestamp}}</i></p>
+
+
   <h3>Description</h3>
   <p>{{survey.description}}</p>
 
+
+  <h3>Response</h3>
+
   {% if survey.response_id %}
-    <a href="{{url_for('response.view_response', survey_id=survey.id, _external=True)}}">
-      View or edit response
+
+    <p><i>Created by: {{ survey.response.created_by.email}} </i></p>
+
+    <a href="{{url_for('response.view_response', survey_id=survey.id, _external=True)}}"
+       class="btn btn-primary"
+       role="button"
+    />
+      {{ render_icon("eye") }} View response
     </a>
-    <p> Response created by: {{ survey.response.created_by.email}} </p>
+
   {% else %}
-    <p>No response available.</p>
-    <a href="{{url_for('response.view_response', survey_id=survey.id, _external=True)}}">
-      Create response
+
+    <div class="alert alert-info">
+      <strong>No response available.</strong> Please create a response to
+      enable experts to begin data entry.
+    </div>
+
+    <div class="alert alert-warning">
+      <strong>Warning!</strong> Advise respondents that this application does
+      not support concurrent or collaborative editing, and <strong>it is
+      currently possible to overwrite others' work</strong>. Please take
+      turns or screen-share while editing if input from multiple users is
+      required.
+    </div>
+
+    <a href="{{url_for('response.view_response', survey_id=survey.id, _external=True)}}"
+       class="btn btn-success"
+       role="button"
+    />
+      {{ render_icon("plus-circle-fill") }} Create response
     </a>
 
-  <br>
-  <h4>Diagram</h4>
-
-
-{% block content %}
-  {% include 'includes/highcharts.html' %}
-
-  {{super()}}
-
-  <p>Created: {{response.created_timestamp}}</p>
-  <p>Last updated: {{response.updated_timestamp}}</p>
-
-  {% if sankey_series == [] %}
-    <div>Please input at least one relationship to display diagram</div>
-  {% else %}
-    <figure class="highcharts-figure">
-      <div id="highcharts-container" />
-    </figure>
-    {{ add_javascript__highcharts(sankey_series) }}
-  {% endif %}
-
-  <br>
-  <i>ID : {{survey.id}}</i>
-
-  <i>Created: {{survey.created_timestamp}}</i>
-
-    <p><i>
-      IMPORTANT: Advise respondents that this application does not support concurrent or collaborative editing.
-      Please take turns or screen-share while editing if input from multiple users is required.
-    </i></p>
   {% endif %}
 
 {% endblock %}

--- a/usaon_benefit_tool/templates/survey.html
+++ b/usaon_benefit_tool/templates/survey.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% from 'bootstrap5/utils.html' import render_icon %}
-{% from 'macros/javascript_highcharts.j2' import add_javascript__highcharts %}
+{% from 'macros/javascript_highcharts.j2' import display_sankey %}
 
 {% block content %}
 
@@ -25,6 +25,8 @@
     />
       {{ render_icon("eye") }} View response
     </a>
+
+    {{ display_sankey(sankey_series) }}
 
   {% else %}
 

--- a/usaon_benefit_tool/templates/surveys.html
+++ b/usaon_benefit_tool/templates/surveys.html
@@ -27,7 +27,6 @@
         <th>Created On</th>
         <th>Created by</th>
         <th>Response last updated</th>
-        <th>Description</th>
         <th>Status</th>
         <th>Private</th>
         <th>Actions</th>
@@ -43,7 +42,6 @@
         <td>{{survey.created_timestamp}}</td>
         <td>{{survey.created_by.email}}</td>
         <td>{{survey.response.updated_timestamp}}</td>
-        <td>{{survey.description}}</td>
         <td>{{survey.status.id}}</td>
         <td>{{survey.private}}</td>
         <td>

--- a/usaon_benefit_tool/templates/surveys.html
+++ b/usaon_benefit_tool/templates/surveys.html
@@ -6,10 +6,17 @@
   <h2>{% block title %}Surveys{% endblock %}</h1>
 
   {% if current_user.role_id=='admin' %}
-    <a href="{{url_for('survey.new_survey')}}">New survey</a>
+    <a href="{{url_for('survey.new_survey')}}"
+       class="btn btn-success"
+       role="button"
+    />
+      {{ render_icon("plus-circle-fill") }} New survey
+    </a>
   {% endif %}
+
   <br />
   <br />
+
   <table class='table'>
 
     <thead>


### PR DESCRIPTION
- [x] Add diagram preview on survey view page like the one on response view page
- [x] De-emphasize survey ID and Created timestamp
- [x] Remove the word "survey" throughout
- [x] Notes --> Description
- [x] Add some more whitespace
- [x] Move the response by up, and add the word created

This might need a little clean up since I'm not an HTML expert. Let me know if it's more work this way vs. translating this information into github

<!-- readthedocs-preview usaon-benefit-tool start -->
----
📚 Documentation preview 📚: https://usaon-benefit-tool--191.org.readthedocs.build/en/191/

<!-- readthedocs-preview usaon-benefit-tool end -->