### PR TITLE
Add a mechanism to render Markdown in templates

### DIFF
--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -13,8 +13,8 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: 93ba4460e711668fb74971ac655cf80aa7f5bb1151c121e85e8e909541ce0f68
-    osx-64: 0a254441fa9a6819b495bbdff404d47cd65ddf954712cafdc9ef1002b7f436b1
+    linux-64: da02cee698358ec4d07c6663e6427fd72ef3794f5250d7f4978ba4f3fb088089
+    osx-64: 65d913253221c325f89322698fb4cbd0ba554d3252ea24fe93a40924eb65270d
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -1462,6 +1462,32 @@ package:
     sha256: f74d200ffa50c455fbe631ca6564fe5b80c64ab314ec832528cfcdfad2a119d7
   category: main
   optional: false
+- name: markdown
+  version: 3.5.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    importlib-metadata: '>=4.4'
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 323495027ffa625701129acebf861412
+    sha256: 35e8990504cf8dc7e2bb63efd855fb0a0d5c0d77bf79403235e757c24a83ec1d
+  category: main
+  optional: false
+- name: markdown
+  version: 3.5.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    importlib-metadata: '>=4.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 323495027ffa625701129acebf861412
+    sha256: 35e8990504cf8dc7e2bb63efd855fb0a0d5c0d77bf79403235e757c24a83ec1d
+  category: main
+  optional: false
 - name: markdown-it-py
   version: 3.0.0
   manager: conda
@@ -2644,6 +2670,30 @@ package:
   hash:
     md5: 074d0ce7a6261ab8b497c3518796ef3e
     sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
+  category: main
+  optional: false
+- name: types-markdown
+  version: 3.5.0.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-markdown-3.5.0.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9a78be2f67528371edc1bf3f908530b8
+    sha256: a64b305419e2f0d537c42aa9c30285e31e41b852904e85d25243f9bc9a4c6d2d
+  category: main
+  optional: false
+- name: types-markdown
+  version: 3.5.0.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-markdown-3.5.0.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9a78be2f67528371edc1bf3f908530b8
+    sha256: a64b305419e2f0d537c42aa9c30285e31e41b852904e85d25243f9bc9a4c6d2d
   category: main
   optional: false
 - name: typing-extensions

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,10 @@ dependencies:
   - shellcheck ~=0.8.0
   - typing-extensions ~=4.4
 
+  ## Type definitions
+  - types-markdown ~=3.5
+
+
   # Runtime dependencies:
   - gunicorn ~=21.2
   - flask ~=2.2
@@ -27,6 +31,7 @@ dependencies:
   - sqlalchemy ~=1.4
   - psycopg2 ~=2.9
   - flask-sqlalchemy ~=3.0
+  - markdown ~=3.5
 
   - loguru ~=0.6.0
   - werkzeug ~=2.2.3

--- a/usaon_benefit_tool/__init__.py
+++ b/usaon_benefit_tool/__init__.py
@@ -6,6 +6,8 @@ from flask import Flask, session
 from flask_bootstrap import Bootstrap5
 from flask_login import LoginManager
 from flask_sqlalchemy import SQLAlchemy
+from markdown import Markdown
+from markupsafe import Markup
 from sqlalchemy import MetaData
 from sqlalchemy import inspect as sqla_inspect
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -112,6 +114,14 @@ def create_app():
     app.register_blueprint(data_product_application_bp)
     app.register_blueprint(application_societal_benefit_area_bp)
 
-    app.jinja_env.globals.update(sqla_inspect=sqla_inspect, __version__=__version__)
+    app.jinja_env.globals.update(
+        __version__=__version__,
+        sqla_inspect=sqla_inspect,
+    )
+
+    md = Markdown(extensions=['fenced_code'])
+    app.jinja_env.filters.update(
+        markdown=lambda txt: Markup(md.convert(txt)),
+    )
 
     return app

--- a/usaon_benefit_tool/templates/home.html
+++ b/usaon_benefit_tool/templates/home.html
@@ -2,38 +2,7 @@
 
 
 {% block content %}
-  <!--Thinking about how this should be due to the way that it links to Benefit Tool docs -->
-  <h2>{% block title %}Welcome to the US AON Benefit Tool!{% endblock %}</h2>
-    <p><strong>Actions:</strong></p>
-    <ul>
-      <li>View our <a href="{{ url_for("surveys.view_surveys") }}">library of evaluations here.</a></li>
-      <li>Click here to <a href="{{ url_for("surveys.view_surveys") }}">edit or update your own evaluation.</a></li>
-      <li>If you'd like to create a new evaluation please email: <a href="mailto:hazel@iarpccollaborations.org">hazel@iarpccollaborations.org</a> </li>
-      <li>Our <a href="https://docs.google.com/document/d/13DLX3A__M60xMgFbQqk2NMAjZzahn5FZcvB3fWSVRck/edit?usp=sharing">data management plan</a> includes information about how any information you add to the tool will be stored and may be shared. Please review the data management plan here.</li>
-      <li><a href="https://usaon.org/evaluation-and-planning/benefit-tool">Learn more about our Benefit Tool.</a></li>
-    </ul>  
- 
-<p><strong>Introduction</strong></p>  
-<p>The Benefit Tool illustrates links between observing systems, data products, 
-      and applications and shows how they connect to societal benefit. Capabilities 
-      and gaps are given numerical ratings and written descriptions throughout the evaluation. </p> 
- 
-<p>Ratings are given for a particular context by an individual or small team of experts 
-      (called respondents). They are subjective but well-informed representations of reality. 
-      The ratings convey the input of the respondents, not US AON's assessment of a given 
-      product or system. </p> 
- 
-<p>Societal benefit ratings present a particular challenge because benefits are context-dependent
-      and often not quantifiable. Like other Western science evaluation frameworks, the Benefit 
-      Tool struggles to depict this nuance. US AON is moving towards cohort ratings for societal 
-      benefit, in line with recommendations coming out of the Arctic Observing Summit  and the 
-      US AON Expert Committee on Methods. However, the current version of the tool includes 
-      evaluations with more limited assessments of societal benefits. </p> 
- 
-<p>Individual evaluations can show the importance of critical capabilities -- be that the strength 
-      of a long-term observing system, the value of a robust communication system, the impact of 
-      data product improvements, or more -- or the impact of specific gaps. As more people use 
-      the Benefit Tool, the value of the evaluations grows. We will begin to see more systemic 
-      strengths and weaknesses in the Arctic observing system, and opportunities to invest in systems 
-      that will have wide-reaching impacts. </p>
+  {% filter markdown %}
+    {% include "home.md" %}
+  {% endfilter %}
 {% endblock %}

--- a/usaon_benefit_tool/templates/home.md
+++ b/usaon_benefit_tool/templates/home.md
@@ -1,0 +1,43 @@
+{# Thinking about how this should be due to the way that it links to Benefit Tool docs #} 
+
+## {% block title %}Welcome to the US AON Benefit Tool!{% endblock %}
+
+### Actions
+
+* [View our library of evaluations]({{ url_for("surveys.view_surveys") }}).
+* [Edit or update your own evaluation]({{ url_for("surveys.view_surveys") }}).
+* If you'd like to create a new evaluation please email: [hazel@iarpccollaborations.org](mailto:hazel@iarpccollaborations.org)
+* Our [data management plan](https://docs.google.com/document/d/13DLX3A__M60xMgFbQqk2NMAjZzahn5FZcvB3fWSVRck/edit?usp=sharing)
+  includes information about how any information you add to the tool will be stored and may be shared.
+* [Learn more about our Benefit Tool](https://usaon.org/evaluation-and-planning/benefit-tool).
+
+
+### Introduction
+
+The Benefit Tool illustrates links between observing systems, data products, and
+applications and shows how they connect to societal benefit.
+Capabilities and gaps are given numerical ratings and written descriptions throughout
+the evaluation. 
+ 
+Ratings are given for a particular context by an individual or small team of experts
+(called respondents).
+They are subjective but well-informed representations of reality.
+The ratings convey the input of the respondents, not US AON's assessment of a given
+product or system.
+ 
+Societal benefit ratings present a particular challenge because benefits are context-dependent
+and often not quantifiable.
+Like other Western science evaluation frameworks, the Benefit Tool struggles to depict
+this nuance.
+US AON is moving towards cohort ratings for societal benefit, in line with
+recommendations coming out of the Arctic Observing Summit  and the US AON Expert
+Committee on Methods.
+However, the current version of the tool includes evaluations with more limited
+assessments of societal benefits.
+ 
+Individual evaluations can show the importance of critical capabilities -- be that the strength 
+of a long-term observing system, the value of a robust communication system, the impact of 
+data product improvements, or more -- or the impact of specific gaps.
+As more people use the Benefit Tool, the value of the evaluations grows.
+We will begin to see more systemic strengths and weaknesses in the Arctic observing
+system, and opportunities to invest in systems that will have wide-reaching impacts.


### PR DESCRIPTION
@hazelshapiro We can now extract pieces of templates in to markdown files, following the pattern in this PR, so commonly-edited text can be made more user-friendly.

This doesn't solve one common problem: Generating correct URLs requires the use of a Jinja templating function. We also need to use Jinja templating to indicate which part of the Markdown file is the document title. You'll see what I mean in the `.md` file in this PR.

There are more user-friendly ways of doing this, and we can make iterative improvements as we go. At least now we have a basic pattern established.