### PR TITLE
Add workflow to make RTD PR previews more findable

### DIFF
--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -1,0 +1,19 @@
+# The ReadTheDocs preview link is "hidden" within the GitHub "Checks"
+# interface. For users who don't know this, finding the preview link may be
+# very difficult or frustrating. This workflow makes the link more
+# findable by updating PR descriptions to include it.
+name: "Add ReadTheDocs preview link to PR descriptions"
+
+on:
+  pull_request_target:
+
+permissions:
+  pull-requests: "write"
+
+jobs:
+  autolink-rtd-previews:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "readthedocs/actions/preview@v1"
+        with:
+          project-slug: "usaon-benefit-tool"


### PR DESCRIPTION
Adds a comment to each PR description with link to RTD. This link is normally well-hidden in the GH Checks interface.

When it goes, it looks like: https://github.com/mfisher87/earthaccess/pull/11