### PR TITLE
Attempt to fix login redirect behaviors

### DIFF
--- a/usaon_benefit_tool/__init__.py
+++ b/usaon_benefit_tool/__init__.py
@@ -78,8 +78,7 @@ def create_app():
             if time.time() >= token['expires_at']:
                 del s['google_oauth_token']
 
-    from usaon_benefit_tool.routes.google import google_bp
-    from usaon_benefit_tool.routes.login import login_bp
+    from usaon_benefit_tool.routes.login import google_bp, login_bp
     from usaon_benefit_tool.routes.logout import logout_bp
     from usaon_benefit_tool.routes.response import response_bp
     from usaon_benefit_tool.routes.response.applications import application_bp

--- a/usaon_benefit_tool/routes/google.py
+++ b/usaon_benefit_tool/routes/google.py
@@ -1,9 +1,0 @@
-import os
-
-from flask_dance.contrib.google import make_google_blueprint
-
-google_bp = make_google_blueprint(
-    client_id=os.getenv('USAON_BENEFIT_TOOL_GOOGLE_CLIENT_ID'),
-    client_secret=os.getenv('USAON_BENEFIT_TOOL_GOOGLE_CLIENT_SECRET'),
-    scope=["profile", "email"],
-)

--- a/usaon_benefit_tool/routes/login.py
+++ b/usaon_benefit_tool/routes/login.py
@@ -1,30 +1,34 @@
+import os
+
 from flask import Blueprint, redirect, url_for
-from flask_dance.contrib.google import google
+from flask_dance.consumer import oauth_authorized
+from flask_dance.contrib.google import google, make_google_blueprint
 from flask_login import login_user
 
 from usaon_benefit_tool.util.db.user import ensure_user_exists
 
 login_bp = Blueprint('login', __name__, url_prefix='/login')
+google_bp = make_google_blueprint(
+    client_id=os.getenv('USAON_BENEFIT_TOOL_GOOGLE_CLIENT_ID'),
+    client_secret=os.getenv('USAON_BENEFIT_TOOL_GOOGLE_CLIENT_SECRET'),
+    scope=["profile", "email"],
+)
 
 
 @login_bp.route("")
 def login():
     if not google.authorized:
         return redirect(url_for("google.login"))
-    resp = google.get("/oauth2/v2/userinfo")
-    assert resp.ok, resp.text
-
-    user = ensure_user_exists(resp.json())
-    login_user(user)
 
     return redirect(url_for('root.root'))
 
 
-# this may be the login issue
-# @app.before_request
-# def before_request():
-#     """Handle expired google tokens as a pre-request hook."""
-#     if token := (s := session).get('google_oauth_token'):
-#         print("Token expiring in", token['expires_at'] - time.time())
-#         if time.time() >= token['expires_at']:
-#             del s['google_oauth_token']
+@oauth_authorized.connect_via(google_bp)
+def google_logged_in(blueprint):
+    # TODO: Flash a message?
+    account_data = blueprint.session.get("/oauth2/v2/userinfo")
+
+    user = ensure_user_exists(account_data.json())
+    login_user(user)
+
+    return redirect(url_for('root.root'))


### PR DESCRIPTION
Must be tested behind proxy to know if it works. I identified two problems here:

1) `flask-dance` was redirecting to `/` by default, but the app in production is hosted behind a proxy at `/apps/benefit-tool`. We need to generate the correct URL with `url_for` for the proxy to be taken
in to account.
2) The old login route needs to be hit twice to actually log in a user. The first time through, it sends the user to Google, and at the end of that, the user winds back up in the app without having hit the `login_user()` call. At this point, Google has authorized the user, so when they hit `/login` again, they'll hit the `login_user()` call.

Both of these problems are addressed by hooking the `oauth_authorized` signal (https://flask-dance.readthedocs.io/en/latest/signals.html) and moving the login & user-insertion behavior there.

Resolves #178 
Resolves #58 

<!-- readthedocs-preview usaon-benefit-tool start -->
----
📚 Documentation preview 📚: https://usaon-benefit-tool--211.org.readthedocs.build/en/211/

<!-- readthedocs-preview usaon-benefit-tool end -->