### PR TITLE
Improve login UX, including post-login redirect

### DIFF
--- a/usaon_benefit_tool/__init__.py
+++ b/usaon_benefit_tool/__init__.py
@@ -44,6 +44,11 @@ def create_app():
     app.config['SQLALCHEMY_DATABASE_URI'] = db_connstr(app)
     app.config['BOOTSTRAP_BOOTSWATCH_THEME'] = 'cosmo'
 
+    # Set flask-login to pass redirection URL by session. This is needed because the
+    # default is to pass it in the request args (i.e. URL query string); this does not
+    # survive the Google OAuth dance by flask-dance.
+    app.config['USE_SESSION_FOR_NEXT'] = True
+
     # DEV ONLY: Disable login
     app.config['LOGIN_DISABLED'] = envvar_is_true("USAON_BENEFIT_TOOL_LOGIN_DISABLED")
 
@@ -51,8 +56,11 @@ def create_app():
         app.wsgi_app = ProxyFix(app.wsgi_app, x_prefix=1)  # type: ignore
 
     db.init_app(app)
+
     Bootstrap5(app)
+
     login_manager = LoginManager()
+    login_manager.login_view = "login.login"
     login_manager.init_app(app)
 
     from usaon_benefit_tool.models.tables import User

--- a/usaon_benefit_tool/routes/login.py
+++ b/usaon_benefit_tool/routes/login.py
@@ -1,9 +1,16 @@
 import os
 
-from flask import Blueprint, redirect, url_for
+from flask import (
+    Blueprint,
+    flash,
+    redirect,
+    render_template,
+    session,
+    url_for,
+)
 from flask_dance.consumer import oauth_authorized
-from flask_dance.contrib.google import google, make_google_blueprint
-from flask_login import login_user
+from flask_dance.contrib.google import make_google_blueprint
+from flask_login import current_user, login_user
 
 from usaon_benefit_tool.util.db.user import ensure_user_exists
 
@@ -17,18 +24,22 @@ google_bp = make_google_blueprint(
 
 @login_bp.route("")
 def login():
-    if not google.authorized:
-        return redirect(url_for("google.login"))
+    if current_user.is_authenticated:
+        return redirect(url_for('root.root'))
 
-    return redirect(url_for('root.root'))
+    return render_template("login.html")
 
 
 @oauth_authorized.connect_via(google_bp)
 def google_logged_in(blueprint, token):  # noqa: ARG001
-    # TODO: Flash a message?
     account_data = blueprint.session.get("/oauth2/v2/userinfo")
 
     user = ensure_user_exists(account_data.json())
     login_user(user)
+    flash("You are now logged in.")
+
+    next_url = session.get("next")
+    if next_url:
+        return redirect(next_url)
 
     return redirect(url_for('root.root'))

--- a/usaon_benefit_tool/routes/logout.py
+++ b/usaon_benefit_tool/routes/logout.py
@@ -1,10 +1,11 @@
 from flask import Blueprint, redirect, url_for
-from flask_login import logout_user
+from flask_login import login_required, logout_user
 
 logout_bp = Blueprint('logout', __name__, url_prefix='/logout')
 
 
 @logout_bp.route("")
+@login_required
 def logout():
     logout_user()
     return redirect(url_for("root.root"))

--- a/usaon_benefit_tool/routes/response/__init__.py
+++ b/usaon_benefit_tool/routes/response/__init__.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, render_template
+from flask_login import login_required
 
 from usaon_benefit_tool import db
 from usaon_benefit_tool.models.tables import Response, Survey
@@ -9,6 +10,7 @@ response_bp = Blueprint('response', __name__, url_prefix='/response')
 
 
 @response_bp.route('/<string:survey_id>', methods=['GET'])
+@login_required
 def view_response(survey_id: str):
     """View or create response to a survey."""
     # Anyone should be able to view a survey

--- a/usaon_benefit_tool/routes/response/applications.py
+++ b/usaon_benefit_tool/routes/response/applications.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, redirect, render_template, request, url_for
+from flask_login import login_required
 
 from usaon_benefit_tool import db
 from usaon_benefit_tool.forms import FORMS_BY_MODEL
@@ -14,6 +15,7 @@ application_bp = Blueprint(
 
 
 @application_bp.route('', methods=['GET', 'POST'])
+@login_required
 def view_response_applications(survey_id: int):
     """View and add to applications associated with a response."""
     Form = FORMS_BY_MODEL[ResponseApplication]
@@ -45,6 +47,7 @@ def view_response_applications(survey_id: int):
 
 
 @application_bp.route('/<int:response_application_id>', methods=['DELETE'])
+@login_required
 def delete_response_application(survey_id: int, response_application_id: int):
     """Delete application response object from survey."""
     survey = db.get_or_404(Survey, survey_id)

--- a/usaon_benefit_tool/routes/response/data_products.py
+++ b/usaon_benefit_tool/routes/response/data_products.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, redirect, render_template, request, url_for
+from flask_login import login_required
 
 from usaon_benefit_tool import db
 from usaon_benefit_tool.forms import FORMS_BY_MODEL
@@ -14,6 +15,7 @@ data_product_bp = Blueprint(
 
 
 @data_product_bp.route('', methods=['GET', 'POST'])
+@login_required
 def view_response_data_products(survey_id: str):
     """View and add to data products associated with a response."""
     Form = FORMS_BY_MODEL[ResponseDataProduct]
@@ -45,6 +47,7 @@ def view_response_data_products(survey_id: str):
 
 
 @data_product_bp.route('/<int:response_data_product_id>', methods=['DELETE'])
+@login_required
 def delete_response_data_product(survey_id: int, response_data_product_id: int):
     """Delete data product response object from survey."""
     survey = db.get_or_404(Survey, survey_id)

--- a/usaon_benefit_tool/routes/response/observing_systems.py
+++ b/usaon_benefit_tool/routes/response/observing_systems.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, redirect, render_template, request, url_for
+from flask_login import login_required
 
 from usaon_benefit_tool import db
 from usaon_benefit_tool._types import ObservingSystemType
@@ -14,6 +15,7 @@ observing_system_bp = Blueprint(
 
 
 @observing_system_bp.route('', methods=['GET', 'POST'])
+@login_required
 def view_response_observing_systems(survey_id: str):
     """View and add to observing systems associated with a response."""
     Form = FORMS_BY_MODEL[ResponseObservingSystem]
@@ -49,6 +51,7 @@ def view_response_observing_systems(survey_id: str):
 
 
 @observing_system_bp.route('/<int:response_observing_system_id>', methods=['DELETE'])
+@login_required
 def delete_response_observing_system(survey_id: int, response_observing_system_id: int):
     """Delete observing system response object from survey."""
     survey = db.get_or_404(Survey, survey_id)

--- a/usaon_benefit_tool/routes/response/sbas.py
+++ b/usaon_benefit_tool/routes/response/sbas.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, redirect, render_template, request, url_for
+from flask_login import login_required
 
 from usaon_benefit_tool import db
 from usaon_benefit_tool.forms import FORMS_BY_MODEL
@@ -18,6 +19,7 @@ societal_benefit_area_bp = Blueprint(
 
 
 @societal_benefit_area_bp.route('', methods=['GET', 'POST'])
+@login_required
 def view_response_sbas(survey_id: str):
     """View and add to observing systems associated with a response."""
     sbas = SocietalBenefitArea.query.all()
@@ -55,6 +57,7 @@ def view_response_sbas(survey_id: str):
     '/<int:response_societal_benefit_area_id>',
     methods=['DELETE'],
 )
+@login_required
 def delete_response_sba(survey_id: int, response_societal_benefit_area_id: int):
     """Delete societal benefit area response object from survey."""
     survey = db.get_or_404(Survey, survey_id)

--- a/usaon_benefit_tool/routes/root.py
+++ b/usaon_benefit_tool/routes/root.py
@@ -5,6 +5,4 @@ root_bp = Blueprint('root', __name__, url_prefix='/')
 
 @root_bp.route('')
 def root():
-    return render_template(
-        'home.html',
-    )
+    return render_template('home.html')

--- a/usaon_benefit_tool/routes/survey.py
+++ b/usaon_benefit_tool/routes/survey.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, redirect, render_template, request, url_for
+from flask_login import login_required
 
 from usaon_benefit_tool import db
 from usaon_benefit_tool.forms import FORMS_BY_MODEL
@@ -8,6 +9,7 @@ survey_bp = Blueprint('survey', __name__, url_prefix='/survey')
 
 
 @survey_bp.route('/new', methods=['GET', 'POST'])
+@login_required
 def new_survey():
     Form = FORMS_BY_MODEL[Survey]
     survey = Survey()
@@ -28,6 +30,7 @@ def new_survey():
 
 
 @survey_bp.route('/<string:survey_id>')
+@login_required
 def view_survey(survey_id: str):
     # Fetch survey by id
     survey = db.get_or_404(Survey, survey_id)

--- a/usaon_benefit_tool/routes/surveys.py
+++ b/usaon_benefit_tool/routes/surveys.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, render_template
+from flask_login import login_required
 
 from usaon_benefit_tool.models.tables import Survey
 
@@ -6,6 +7,7 @@ surveys_bp = Blueprint('surveys', __name__, url_prefix='/surveys')
 
 
 @surveys_bp.route('')
+@login_required
 def view_surveys():
     surveys = Survey.query.order_by(Survey.created_timestamp).all()
     return render_template(

--- a/usaon_benefit_tool/routes/user.py
+++ b/usaon_benefit_tool/routes/user.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, flash, render_template, request
-from flask_login import current_user
+from flask_login import current_user, login_required
 
 from usaon_benefit_tool import db
 from usaon_benefit_tool.forms import FORMS_BY_MODEL
@@ -15,6 +15,7 @@ user_bp = Blueprint('user', __name__, url_prefix='/user')
 
 
 @user_bp.route('/<user_id>', methods=['POST', 'GET'])
+@login_required
 def user(user_id: str):
     Form = FORMS_BY_MODEL[User]
     user = db.get_or_404(User, user_id)

--- a/usaon_benefit_tool/routes/users.py
+++ b/usaon_benefit_tool/routes/users.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, render_template
+from flask_login import login_required
 
 from usaon_benefit_tool.models.tables import User
 
@@ -6,6 +7,7 @@ users_bp = Blueprint('users', __name__, url_prefix='/users')
 
 
 @users_bp.route('')
+@login_required
 def view_users():
     users = User.query.order_by(User.name).all()
     return render_template(

--- a/usaon_benefit_tool/static/style.css
+++ b/usaon_benefit_tool/static/style.css
@@ -1,3 +1,11 @@
+#login-banner {
+  /* background-color: var(--bs-warning); */
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+
+/* Footer stuff */
 body {
   min-height: 100vh;
   display: flex;
@@ -14,6 +22,8 @@ footer {
   justify-content: space-between;
 }
 
+
+/* Nav stuff */
 nav ul {
   list-style-type: none;
   padding: 0px;
@@ -25,6 +35,8 @@ nav ul li {
   padding-right: 15px;
 }
 
+
+/* Content stuff */
 .content {
   padding-top: 20px;
 }

--- a/usaon_benefit_tool/templates/base.html
+++ b/usaon_benefit_tool/templates/base.html
@@ -9,6 +9,7 @@
 </head>
 
 <body>
+
   <nav class="navbar navbar-expand-lg bg-primary" data-bs-theme="dark">
     <div class="container">
       <a class="navbar-brand" href={{ url_for('root.root')}}>US AON Benefit Tool</a>
@@ -19,23 +20,29 @@
       </div>
     </div>
   </nav>
-  {{ render_messages() }}
+
+
+  {% if not current_user.is_authenticated %}
+    <div id="login-banner" class="alert alert-warning">
+      Please <a href={{ url_for('login.login') }}>log in</a> to use this application.
+    </div>
+  {% endif %}
+
+  {{ render_messages(container=False, dismissible=True, dismiss_animate=True) }}
+
+
   <section class="content">
     <div class="container">
 
       <header>
         {% block header %}{% endblock %}
       </header>
-      
 
-      {% if not current_user.is_authenticated %}
-        <h3>Please login to use this application.</h3>
-      {% else %}
-        {% block content %}{% endblock %}
-      {% endif %}
+      {% block content %}{% endblock %}
 
     </div>
   </section>
+
 
   <footer>
     <hr />
@@ -44,5 +51,9 @@
       <p>Version: v{{ __version__ }}</p>
     </div>
   </footer>
-  
+
+  {% block scripts %}
+    {{ bootstrap.load_js() }}
+  {% endblock %}
+
 </body>

--- a/usaon_benefit_tool/templates/login.html
+++ b/usaon_benefit_tool/templates/login.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% from 'bootstrap5/utils.html' import render_icon %}
+
+{% block content %}
+
+  <div class="d-grid gap-2">
+
+    <a href="{{ url_for("google.login") }}"
+       class="btn btn-outline-primary"
+       role="button"
+    />
+      {{ render_icon("google") }} Sign in with Google
+    </a>
+
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
Resolves #213

* Display banner when not logged in.
* New login page with button to let user know we're using Google SSO. We can add more provider here later.
* Restricted routes. We weren't restricting pages previously, we were only handling login status in the base template.
* When accessing restricted routes, redirect to login page. * If the user chooses to login now, they'll be redirected to the restricted route they tried to access earlier.

<!-- readthedocs-preview usaon-benefit-tool start -->
----
📚 Documentation preview 📚: https://usaon-benefit-tool--215.org.readthedocs.build/en/215/

<!-- readthedocs-preview usaon-benefit-tool end -->