### PR TITLE
Change "Surveys" to "Projects" in nav bar and target page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## NEXT_VERSION
+
+* Refer to "Surveys" as "Projects" in the user interface
+    * This is a temporary change for user testing, see #228 for long-term
+      decision-making
+
+
 ## v1.5.0 (2023-12-21)
 
 * Adopt a suitable webserver for production: Gunicorn

--- a/usaon_benefit_tool/templates/home.md
+++ b/usaon_benefit_tool/templates/home.md
@@ -4,8 +4,8 @@
 
 ### Actions
 
-* [View our library of evaluations]({{ url_for("surveys.view_surveys") }}).
-* [Edit or update your own evaluation]({{ url_for("surveys.view_surveys") }}).
+* [View our library of projects]({{ url_for("surveys.view_surveys") }}).
+* [Edit or update your own project]({{ url_for("surveys.view_surveys") }}).
 * If you'd like to create a new evaluation please email: [hazel@iarpccollaborations.org](mailto:hazel@iarpccollaborations.org)
 * Our [data management plan](https://docs.google.com/document/d/13DLX3A__M60xMgFbQqk2NMAjZzahn5FZcvB3fWSVRck/edit?usp=sharing)
   includes information about how any information you add to the tool will be stored and may be shared.

--- a/usaon_benefit_tool/templates/macros/nav_buttons.j2
+++ b/usaon_benefit_tool/templates/macros/nav_buttons.j2
@@ -2,7 +2,7 @@
   {% from "bootstrap5/nav.html" import render_nav_item %}
 
   {{ render_nav_item("root.root", "Home", _use_li=True)}}
-  {{ render_nav_item("surveys.view_surveys", "Surveys", _use_li=True)}}
+  {{ render_nav_item("surveys.view_surveys", "Projects", _use_li=True)}}
 {%- endmacro -%}
 
 

--- a/usaon_benefit_tool/templates/new_survey.html
+++ b/usaon_benefit_tool/templates/new_survey.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-  <h2>{% block title %}New Survey{% endblock %}</h1>
+  <h2>{% block title %}New Project{% endblock %}</h1>
 
   <form method="POST">
 		{{form.csrf_token}}
@@ -26,7 +26,7 @@
 			</ul>
 		{% endif %}
 
-    <input type="submit" value="Create new survey" />
+    <input type="submit" value="Create new project" />
 
   </form>
 

--- a/usaon_benefit_tool/templates/survey/base.html
+++ b/usaon_benefit_tool/templates/survey/base.html
@@ -6,7 +6,7 @@
 {% block content %}
 
   <h2>
-    {% block title %}Survey #{{survey.id}}: {{survey.title}}{% endblock %}
+    {% block title %}Project #{{survey.id}}: {{survey.title}}{% endblock %}
     {{ help_icon(
         "Created: "~survey.response.created_timestamp | dateformat~"<br/>Last updated: "~survey.response.updated_timestamp | dateformat,
         html="true",

--- a/usaon_benefit_tool/templates/surveys.html
+++ b/usaon_benefit_tool/templates/surveys.html
@@ -4,7 +4,7 @@
 
 
 {% block content %}
-  <h2>{% block title %}Surveys{% endblock %}</h1>
+  <h2>{% block title %}Projects{% endblock %}</h1>
 
   {% if current_user.role_id=='admin' %}
     <a href="{{url_for('survey.new_survey')}}"


### PR DESCRIPTION
Closes #217

@hazelshapiro I think we want to change "Surveys" to "Projects" in more places, right? Maybe we also want to remove the concept of "responses", since every survey has exactly 1 response as-is?

## TODO

- [x] CHANGELOG

<!-- readthedocs-preview usaon-benefit-tool start -->
----
📚 Documentation preview 📚: https://usaon-benefit-tool--219.org.readthedocs.build/en/219/

<!-- readthedocs-preview usaon-benefit-tool end -->