### PR TITLE
Add support for tooltips and put one on the survey response view page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Surveys & response page user experience enhancements
 
+* Hide some noisy info under a tooltip
 * More consistent button style
 * Make some columns admin-only
 * Re-order columns for readability

--- a/usaon_benefit_tool/templates/base.html
+++ b/usaon_benefit_tool/templates/base.html
@@ -54,6 +54,14 @@
 
   {% block scripts %}
     {{ bootstrap.load_js() }}
+
+    <!-- init tooltips (https://getbootstrap.com/docs/5.0/components/tooltips/) -->
+    <script type="text/javascript">
+      var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+      var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+        return new bootstrap.Tooltip(tooltipTriggerEl)
+      })
+    </script>
   {% endblock %}
 
 </body>

--- a/usaon_benefit_tool/templates/macros/help_icon.j2
+++ b/usaon_benefit_tool/templates/macros/help_icon.j2
@@ -1,0 +1,7 @@
+{% from 'bootstrap5/utils.html' import render_icon %}
+
+{% macro help_icon(text, html="false") -%}
+  <span data-bs-toggle="tooltip" data-bs-html="{{html}}", title="{{text}}">
+    {{ render_icon("info-circle", size="0.5em", color="info") }}
+  </span>
+{%- endmacro -%}

--- a/usaon_benefit_tool/templates/response/base.html
+++ b/usaon_benefit_tool/templates/response/base.html
@@ -1,10 +1,17 @@
 {% extends 'base.html' %}
+{% from 'macros/help_icon.j2' import help_icon %}
 
 
 {% block content %}
 
-  <h2>{% block title %}Response to: {{survey.title}}{% endblock %}</h1>
-  <p>Survey #{{survey.id}}</p>
+  <h2>
+    {% block title %}Response to: {{survey.title}}{% endblock %}
+    {{ help_icon(
+        "Survey #"~survey.id~"<br/>Created: "~response.created_timestamp | dateformat~"<br/>Last updated: "~response.updated_timestamp | dateformat,
+        html="true",
+    )}}
+  </h2>
+
 
   <nav>
     <ul>

--- a/usaon_benefit_tool/templates/response/view.html
+++ b/usaon_benefit_tool/templates/response/view.html
@@ -6,9 +6,6 @@
 
   {{super()}}
 
-  <p>Created: {{response.created_timestamp | dateformat}}</p>
-  <p>Last updated: {{response.updated_timestamp | dateformat}}</p>
-
   {{ display_sankey(sankey_series) }}
 
 {% endblock %}


### PR DESCRIPTION
Related to #179 but does not resolve.

Adds support for tooltips and puts some noisy information under a tooltip to demo.

<!-- readthedocs-preview usaon-benefit-tool start -->
----
📚 Documentation preview 📚: https://usaon-benefit-tool--224.org.readthedocs.build/en/224/

<!-- readthedocs-preview usaon-benefit-tool end -->