### PR TITLE
Generate tooltip HTML in Python before passing data to Highcharts

### DIFF
--- a/usaon_benefit_tool/templates/assessment/_edit_node.html
+++ b/usaon_benefit_tool/templates/assessment/_edit_node.html
@@ -5,7 +5,15 @@
   <div class="modal-header">
     <h5 class="modal-title">
       Edit node: {{node.short_name}}
+      <a href="{{ url_for("node.get", node_id=node.id) }}" target="_blank">
+        #{{ node.id }} {{ render_icon("box-arrow-up-right") }}
+      </a>
     </h5>
+
+    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
+  </div>
+
+  <div class="modal-body">
 
     {{delete_button_htmx(
       'assessment.node.delete',
@@ -40,9 +48,5 @@
       {{ render_icon("box-arrow-right") }} Add target link
     </button>
 
-    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-  </div>
-
-  <div class="modal-body">
   </div>
 </div>

--- a/usaon_benefit_tool/templates/macros/javascript_highcharts.j2
+++ b/usaon_benefit_tool/templates/macros/javascript_highcharts.j2
@@ -11,7 +11,7 @@
       const selector = "#form-modal";
       const el = document.querySelector(selector);
 
-      // Determine the target URL and set the hx-get parameter // accordingly.
+      // Determine the target URL and set the hx-get parameter accordingly.
       // We're using vendored Flask-JSGlue to do this from JS.
       // TODO: Less magic string processing
       const isNode = "type" in point;
@@ -73,28 +73,9 @@
       },
       tooltip: {
         headerFormat: null,
-        nodeFormatter: function() {
+        formatter: function() {
           const point = this;
-          if (point.id === "{{ constants.DUMMY_NODE_ID }}") {
-            // FIXME: This method of hiding a tooltip works for `formatter`, but not `nodeFormatter`.
-            // return false;
-            return point.name
-          }
-          const tooltipName = "<b>" + point.name + "</b>: ";
-          if (point.linksTo[0].from === "{{ constants.DUMMY_NODE_ID }}") {
-            return tooltipName + "Click me to add link(s)!";
-          }
-
-          return tooltipName + point.sum;
-        },
-        pointFormatter: function() {
-          const point = this;
-          if (point.from === "{{ constants.DUMMY_NODE_ID }}") {
-            // FIXME: This method of hiding a tooltip works for `formatter`, but not `pointFormatter`.
-            // return false;
-            return point.fromNode.name;
-          }
-          return "<b>" + point.fromNode.name + "</b> → <b>" + point.toNode.name + "</b>: " + point.weight;
+          return point.point.tooltipHTML || false;
         },
       },
       series: [{

--- a/usaon_benefit_tool/templates/partials/link_tooltip.html
+++ b/usaon_benefit_tool/templates/partials/link_tooltip.html
@@ -1,0 +1,13 @@
+{# NOTE: This seems like it's going to lead to a bunch of queries #}
+<b>{{link.source_assessment_node.node.short_name}}</b>
+→
+<b>{{link.target_assessment_node.node.short_name}}</b>
+
+<br/>
+<br/>
+
+<b>Criticality rating:</b> {{ link.criticality_rating }}
+<br />
+
+<b>Performance rating:</b> {{ link.performance_rating }}
+<br />

--- a/usaon_benefit_tool/templates/partials/node_tooltip.html
+++ b/usaon_benefit_tool/templates/partials/node_tooltip.html
@@ -1,0 +1,14 @@
+{# NOTE: This seems like it's going to lead to a bunch of queries #}
+<b>{{assessment_node.node.short_name}}</b>
+
+<br />
+<br />
+
+<b>Title:</b> {{assessment_node.node.title}}
+<br />
+
+<b>Type:</b> {{assessment_node.node.type.value}}
+<br />
+
+<b>Description:</b> {{assessment_node.node.description}}
+<br />


### PR DESCRIPTION
Closes #52. I know this may not be a complete solution, but it's a best attempt at translating from the legacy app, and helps us define where we want to go from there. Let's open further tickets to refine.

Highcharts just uses the `tooltipHTML` data it finds on the hovered point. Since we need to access the relevant data in the Python anyway, this makes sense logically.

However, there's a performance cost of this implementation, as noted in comments. Those templates are being rendered lots of times and I think they're going to be triggering lots of queries. At our scale, we'll probably be fine, but there's room for optimization here when we find the need.

<!-- readthedocs-preview usaon-benefit-tool start -->
----
📚 Documentation preview 📚: https://usaon-benefit-tool--276.org.readthedocs.build/en/276/

<!-- readthedocs-preview usaon-benefit-tool end -->