### PR TITLE
Allow users to edit their profiles

### DIFF
--- a/usaon_benefit_tool/routes/user.py
+++ b/usaon_benefit_tool/routes/user.py
@@ -31,7 +31,7 @@ def get(user_id: str):
 @user_bp.route('/<user_id>', methods=['POST'])
 @login_required
 def post(user_id: str):
-    if user_id != request.form['id']:
+    if user_id != current_user.id and current_user.role_id != RoleName.ADMIN:
         forbid_except_for_roles([RoleName.ADMIN])
 
     user = db.get_or_404(User, user_id)

--- a/usaon_benefit_tool/routes/user.py
+++ b/usaon_benefit_tool/routes/user.py
@@ -31,7 +31,8 @@ def get(user_id: str):
 @user_bp.route('/<user_id>', methods=['POST'])
 @login_required
 def post(user_id: str):
-    forbid_except_for_roles([RoleName.ADMIN])
+    if user_id != request.form['id']:
+        forbid_except_for_roles([RoleName.ADMIN])
 
     user = db.get_or_404(User, user_id)
     form = Form(request.form, obj=user)

--- a/usaon_benefit_tool/routes/user.py
+++ b/usaon_benefit_tool/routes/user.py
@@ -31,7 +31,7 @@ def get(user_id: str):
 @user_bp.route('/<user_id>', methods=['POST'])
 @login_required
 def post(user_id: str):
-    if user_id != current_user.id and current_user.role_id != RoleName.ADMIN:
+    if user_id != current_user.id:
         forbid_except_for_roles([RoleName.ADMIN])
 
     user = db.get_or_404(User, user_id)


### PR DESCRIPTION
Resolves [#288](https://github.com/nsidc/usaon-benefit-tool/issues/288)

- In the @user_bp.route('/<user_id>', POST) endpoint, added logic to allow users to edit their profiles

<!-- readthedocs-preview usaon-benefit-tool start -->
----
📚 Documentation preview 📚: https://usaon-benefit-tool--289.org.readthedocs.build/en/289/

<!-- readthedocs-preview usaon-benefit-tool end -->